### PR TITLE
Add Tides Controller and Tests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/TidesController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/TidesController.java
@@ -1,9 +1,37 @@
 package edu.ucsb.cs156.spring.backenddemo.controllers;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import edu.ucsb.cs156.spring.backenddemo.services.TidesQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-
+@Tag(name="Tide Information from NOAA https://api.tidesandcurrents.noaa.gov/api/prod/")
+@Slf4j
 @RestController
+@RequestMapping("/api/tides")
 public class TidesController {
+
+    @Autowired
+    TidesQueryService tidesQueryService;
+
+    @Operation(summary = "Get water level for date range, in local time.", description = "For station id, see: https://tidesandcurrents.noaa.gov/tide_predictions.html?gid=1393")
+    @GetMapping("/get")
+    public ResponseEntity<String> getTides(
+            @Parameter(name="beginDate", description="beginDate in format yyyymmdd") @RequestParam String beginDate,
+            @Parameter(name="endDate", description="endDate in format yyyymmdd") @RequestParam String endDate,
+            @Parameter(name="station", description="station", example="9411340 for Santa Barbara") @RequestParam String station
+    ) throws JsonProcessingException {
+        log.info("getTides: beginDate={} endDate={} station={}", beginDate, endDate, station);
+        String result = tidesQueryService.getJSON(beginDate, endDate, station);
+        return ResponseEntity.ok().body(result);
+    }
 
 }

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/TidesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/TidesControllerTests.java
@@ -1,0 +1,49 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.spring.backenddemo.services.EarthquakeQueryService;
+import edu.ucsb.cs156.spring.backenddemo.services.TidesQueryService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@WebMvcTest(value = TidesController.class)
+public class TidesControllerTests {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  TidesQueryService mockTidesQueryService;
+
+  @Test
+  public void test_getTides() throws Exception {
+  
+    String fakeJsonResult="{ \"fake\" : \"result\" }";
+    String beginDate = "20200115";
+    String endDate = "20200120";
+    String station = "9411340";
+    when(mockTidesQueryService.getJSON(eq(beginDate),eq(endDate),eq(station))).thenReturn(fakeJsonResult);
+
+    String url = String.format("/api/tides/get?beginDate=%s&endDate=%s&station=%s",beginDate,endDate,station);
+
+    MvcResult response = mockMvc
+        .perform( get(url).contentType("application/json"))
+        .andExpect(status().isOk()).andReturn();
+
+    String responseString = response.getResponse().getContentAsString();
+
+    assertEquals(fakeJsonResult, responseString);
+  }
+
+}


### PR DESCRIPTION
In this PR, we add an endpoint `/api/tides/get` that can be used to get information about the tides during a specific date range at a particular station. 

Deployed at https://team01-katytsao-dev.dokku-04.cs.ucsb.edu/swagger-ui/index.html

Closes #13